### PR TITLE
Fix missing includes in Timer header

### DIFF
--- a/RcppParallel/include/RcppParallel/Timer.h
+++ b/RcppParallel/include/RcppParallel/Timer.h
@@ -1,5 +1,12 @@
+
 #ifndef __RCPP_PARALLEL_TIMER__
 #define __RCPP_PARALLEL_TIMER__
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <list>
+#include <Rcpp.h>
 
 namespace RcppParallel {
     typedef uint64_t nanotime_t;
@@ -205,4 +212,4 @@ namespace RcppParallel {
 } // namespace RcppParallel
 
 
-#endif // __RCPP_PARALLEL_COMMON__
+#endif // __RCPP_PARALLEL_TIMER__


### PR DESCRIPTION
## Summary
- include standard and Rcpp headers in `Timer.h`
- correct header guard comment

## Testing
- `g++ --version`

------
https://chatgpt.com/codex/tasks/task_e_683f6b07d3848332a0617357be09ef8c